### PR TITLE
cloog_input_read calls cloog_die if OpenScop is specified in options but not supported

### DIFF
--- a/source/input.c
+++ b/source/input.c
@@ -70,6 +70,9 @@ CloogInput *cloog_input_read(FILE *file, CloogOptions *options)
     cloog_options_copy_from_osl_scop(scop, options);
     return input;
   }
+#else
+  if (options->openscop)
+    cloog_die("CLooG has not been compiled with OpenScop support.\n");
 #endif
 
   /* First of all, we read the language to use. */


### PR DESCRIPTION
Apply coding style to cloog_input_read function
cloog_input_read calls cloog_die if OpenScop is specified in options but not supported
