### PR TITLE
annotate_loops(): fix memory leak

### DIFF
--- a/source/program.c
+++ b/source/program.c
@@ -460,6 +460,8 @@ static int annotate_loops(osl_scop_p program, struct clast_stmt *root){
     clast_filter(root, filter, &clastloops, &nclastloops, 
                  &claststmts, &nclaststmts);
 
+    if (claststmts) { free(claststmts); claststmts=NULL;}
+
     /* There should be at least one */
     if (nclastloops==0) {  //FROM PLUTO
        /* Sometimes loops may disappear (1) tile size larger than trip count
@@ -486,7 +488,6 @@ static int annotate_loops(osl_scop_p program, struct clast_stmt *root){
     }
 
     if (clastloops) { free(clastloops); clastloops=NULL;}
-    if (claststmts) { free(claststmts); claststmts=NULL;}
 
     ll = ll->next;
   }


### PR DESCRIPTION
In the previous implementation, `claststmts` would be freed at each end
of the iteration of a while loop. However, if `nclastloops == 0`, the
loop would continue to its next iteration without freeing `claststmts`.

The current implementation frees `claststmts` as soon as it is useless,
ensuring it is always freed.