### PR TITLE
Cloog int selection and ISL integer support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 
+
 dnl /**-------------------------------------------------------------------**
 dnl  **                              CLooG                                **
 dnl  **-------------------------------------------------------------------**
@@ -181,12 +182,31 @@ AC_SUBST(ISL_LIBS)
 case "$with_isl" in
 bundled)
 	ISL_CPPFLAGS="-I$srcdir/isl/include -Iisl/include"
+  CPPFLAGS="-DISL_USING_GMP_VAL=1 $CPPFLAGS"
 	;;
 build)
+  TMPCPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="-I$isl_srcdir/include -I$with_isl_builddir/include $CPPFLAGS"
+  AC_CHECK_HEADER([isl/val_gmp.h])
+  CPPFLAGS="$TMPCPPFLAGS"
+  if test "$ac_cv_header_isl_val_gmp_h" = "yes"; then
+    CPPFLAGS="-DISL_USING_GMP_VAL=1 $CPPFLAGS"
+  else
+    CPPFLAGS="-DISL_USING_GMP_VAL=0 $CPPFLAGS"
+  fi
 	ISL_CPPFLAGS="-I$isl_srcdir/include -I$with_isl_builddir/include"
 	ISL_LIBS="$with_isl_builddir/libisl.la"
 	;;
 system)
+  TMPCPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="-I$with_isl_prefix/include $CPPFLAGS"
+  AC_CHECK_HEADER([isl/val_gmp.h])
+  CPPFLAGS="$TMPCPPFLAGS"
+  if test "$ac_cv_header_isl_val_gmp_h" = "yes"; then
+    CPPFLAGS="-DISL_USING_GMP_VAL=1 $CPPFLAGS"
+  else
+    CPPFLAGS="-DISL_USING_GMP_VAL=0 $CPPFLAGS"
+  fi
 	if test "x$with_isl_prefix" != "x"; then
 		ISL_CPPFLAGS="-I$with_isl_prefix/include"
 	fi
@@ -195,6 +215,8 @@ system)
 	fi
 	ISL_LIBS="-lisl"
 esac
+
+
 AM_CONDITIONAL(BUNDLED_ISL, test $with_isl = bundled)
 AM_CONDITIONAL(NO_ISL, test $with_isl = no)
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,44 +100,74 @@ AC_CHECK_FUNCS([getrusage],
 	[AC_DEFINE([CLOOG_RUSAGE], [], [Print time required to generate code])])
 
 AX_SUBMODULE(isl,no|system|build|bundled,bundled)
-BITS="gmp"
 
 dnl /**************************************************************************
 dnl  *                            Where is GMP?                               *
 dnl  **************************************************************************/
 
+AC_ARG_WITH(cloog-int,
+            [AS_HELP_STRING(
+              [--with-cloog-int=gmp|int|long|longlong],
+              [Integer precision to use (default gmp)])])
+
+if test "x$with_cloog_int" = "x"; then
+  with_cloog_int="gmp"
+fi
+
 AX_SUBMODULE(gmp,system|build,system)
 
 need_get_memory_functions=false
-case "$with_gmp" in
-build)
-    CPPFLAGS="-I$with_gmp_builddir $CPPFLAGS"
-    LDFLAGS="-L$with_gmp_builddir/$lt_cv_objdir $LDFLAGS"
+case "$with_cloog_int" in
+  gmp)
+    BITS="gmp"
+    CLOOG_INT_CONFIGURE="CLOOG_INT_GMP"
+    case "$with_gmp" in
+    build)
+      CPPFLAGS="-I$with_gmp_builddir $CPPFLAGS"
+      LDFLAGS="-L$with_gmp_builddir/$lt_cv_objdir $LDFLAGS"
     ;;
-system)
-    if test "x$with_gmp_prefix" != "x"; then
-	CPPFLAGS="-I$with_gmp_prefix/include $CPPFLAGS"
-    fi
-    
-    if test "$with_gmp_exec_prefix" != "yes" ; then
-	LDFLAGS="-L$with_gmp_exec_prefix/lib $LDFLAGS"
-    fi
+    system)
+      if test "x$with_gmp_prefix" != "x"; then
+        CPPFLAGS="-I$with_gmp_prefix/include $CPPFLAGS"
+      fi
+
+      if test "$with_gmp_exec_prefix" != "yes" ; then
+        LDFLAGS="-L$with_gmp_exec_prefix/lib $LDFLAGS"
+      fi
     ;;
+    esac
+    case "$with_gmp" in
+    build|system)
+      AC_CHECK_HEADER(gmp.h,
+                      [],
+                      [AC_MSG_ERROR(Can't find gmp headers.)])
+      AC_CHECK_LIB(gmp,
+                  __gmpz_init,
+                  [LIBS="$LIBS -lgmp"],
+                  [AC_MSG_ERROR(Can't find gmp library.)])
+      AC_CHECK_DECLS(mp_get_memory_functions,[],[
+        need_get_memory_functions=true
+      ],[#include <gmp.h>])
+    ;;
+    esac
+  ;;
+  int)
+    BITS="int"
+    CLOOG_INT_CONFIGURE="CLOOG_INT_INT"
+  ;;
+  long)
+    BITS="long"
+    CLOOG_INT_CONFIGURE="CLOOG_INT_LONG"
+  ;;
+  longlong)
+    BITS="longlong"
+    CLOOG_INT_CONFIGURE="CLOOG_INT_LONG_LONG"
+  ;;
+  *)
+    AC_MSG_ERROR([Unknown integer type: $with_cloog_int])
+  ;;
 esac
-case "$with_gmp" in
-build|system)
-    AC_CHECK_HEADER(gmp.h,
-                    [],
-                    [AC_MSG_ERROR(Can't find gmp headers.)])
-    AC_CHECK_LIB(gmp,
-                 __gmpz_init,
-                 [LIBS="$LIBS -lgmp"],
-                 [AC_MSG_ERROR(Can't find gmp library.)])
-    AC_CHECK_DECLS(mp_get_memory_functions,[],[
-	    need_get_memory_functions=true
-    ],[#include <gmp.h>])
-    ;;
-esac
+
 AM_CONDITIONAL(NEED_GET_MEMORY_FUNCTIONS,
 		test x$need_get_memory_functions = xtrue)
 
@@ -199,9 +229,6 @@ esac
 AM_CONDITIONAL(BUNDLED_OSL, test $with_osl = bundled)
 AM_CONDITIONAL(NO_OSL, test $with_osl = no)
 
-
-AC_DEFINE([CLOOG_INT_GMP], 1, [Use arbitrary precision integers])
-
 AC_SUBST(GIT_INDEX)
 if test -f $srcdir/.git/HEAD; then
 	GIT_INDEX="\$(top_srcdir)/.git/index"
@@ -222,19 +249,20 @@ AC_SUBST(exec_prefix)
 AC_SUBST(INSTALL)
 
 AC_SUBST(BITS)
+AC_SUBST(CLOOG_INT_CONFIGURE)
 
 AC_SUBST(VERSION_MAJOR)
 AC_SUBST(VERSION_MINOR)
 AC_SUBST(VERSION_REVISION)
 
 PACKAGE_NAME="cloog-isl"
-PACKAGE_CFLAGS="-DCLOOG_INT_GMP=1"
 AX_CREATE_PKGCONFIG_INFO
 
 AC_CONFIG_FILES(Makefile test/Makefile)
 AC_CONFIG_FILES(autoconf/Doxyfile)
 AC_CONFIG_FILES(doc/Makefile)
 AC_CONFIG_FILES(source/version.c)
+AC_CONFIG_FILES(include/cloog/int.h)
 AC_CONFIG_FILES(include/cloog/version.h)
 AC_CONFIG_FILES([genversion.sh], [chmod +x genversion.sh])
 AC_CONFIG_COMMANDS([version.h],

--- a/include/cloog/int.h.in
+++ b/include/cloog/int.h.in
@@ -1,6 +1,13 @@
 #ifndef CLOOG_INT_H
 #define CLOOG_INT_H
 
+#undef CLOOG_INT_INT
+#undef CLOOG_INT_LONG
+#undef CLOOG_INT_LONG_LONG
+#undef CLOOG_INT_GMP
+
+#define @CLOOG_INT_CONFIGURE@
+
 #include <assert.h>
 #include <stdio.h>
 #if defined(CLOOG_INT_GMP)

--- a/include/cloog/isl/cloog.h
+++ b/include/cloog/isl/cloog.h
@@ -1,10 +1,6 @@
 #ifndef CLOOG_ISL_H
 #define CLOOG_ISL_H
 
-#ifndef CLOOG_INT_GMP
-#define CLOOG_INT_GMP
-#endif
-
 #include <cloog/cloog.h>
 #include <cloog/isl/constraintset.h>
 #include <cloog/isl/domain.h>

--- a/m4/ax_submodule.m4
+++ b/m4/ax_submodule.m4
@@ -4,21 +4,16 @@ AC_DEFUN([AX_SUBMODULE],
 AC_ARG_WITH($1,
 	[AS_HELP_STRING([--with-$1=$2],
 			[Which $1 to use])])
-case "system" in
-$2)
 	AC_ARG_WITH($1_prefix,
 		    [AS_HELP_STRING([--with-$1-prefix=DIR],
 				    [Prefix of $1 installation])])
 	AC_ARG_WITH($1_exec_prefix,
 		    [AS_HELP_STRING([--with-$1-exec-prefix=DIR],
 				    [Exec prefix of $1 installation])])
-esac
-case "build" in
-$2)
 	AC_ARG_WITH($1_builddir,
 		    [AS_HELP_STRING([--with-$1-builddir=DIR],
 				    [Location of $1 builddir])])
-esac
+
 if test "x$with_$1_prefix" != "x" -a "x$with_$1_exec_prefix" = "x"; then
 	with_$1_exec_prefix=$with_$1_prefix
 fi
@@ -36,20 +31,11 @@ if test "x$with_$1_builddir" != "x"; then
 	$1_srcdir=`echo @abs_srcdir@ | $with_$1_builddir/config.status --file=-`
 	AC_MSG_NOTICE($1 sources in $$1_srcdir)
 fi
+
 case "$with_$1" in
 $2)
 	;;
 *)
-	if test -d $srcdir/.git -a \
-		-d $srcdir/$1 -a \
-		! -d $srcdir/$1/.git; then
-		AC_MSG_WARN(
-[git repo detected, but submodule $1 not initialized])
-		AC_MSG_WARN([You may want to run])
-		AC_MSG_WARN([	git submodule init])
-		AC_MSG_WARN([	git submodule update])
-		AC_MSG_WARN([	sh autogen.sh])
-	fi
 	if test -f $srcdir/$1/configure -a "$3" != "no"; then
 		with_$1="bundled"
 	else
@@ -57,6 +43,16 @@ $2)
 	fi
 	;;
 esac
+	if test "x$with_$1" = "xbundled" -a -d $srcdir/.git -a \
+		-d $srcdir/$1 -a \
+		! -e $srcdir/$1/.git; then
+		AC_MSG_WARN(
+[git repo detected, but submodule $1 not initialized])
+		AC_MSG_WARN([You may want to run])
+		AC_MSG_WARN([	git submodule init])
+		AC_MSG_WARN([	git submodule update])
+		AC_MSG_WARN([	sh autogen.sh])
+	fi
 AC_MSG_CHECKING([which $1 to use])
 AC_MSG_RESULT($with_$1)
 

--- a/source/isl/domain.c
+++ b/source/isl/domain.c
@@ -11,7 +11,6 @@
 #include <isl/aff.h>
 #include <isl/map.h>
 #include <isl/val.h>
-#include <isl/val_gmp.h>
 
 #ifdef OSL_SUPPORT
 #include <osl/macros.h>


### PR DESCRIPTION
CLooG int can be modifier with configure option --with-cloog-int (default GMP)
CLooG can now link against non GMP ISL flavor (imath or imath-32). Bundled still default to GMP.
