### PR TITLE
configure.ac: fix TEXI2DVI check to handle missing program case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_CHECK_PROG(CD, cd)
 dnl Configure needs an empty install.sh file with this, i HATE that...
 AC_PROG_INSTALL
 LT_INIT
-AC_CHECK_PROG(TEXI2DVI, texi2dvi, texi2dvi, [])
+AC_CHECK_PROG(TEXI2DVI, texi2dvi, [], [])
 AM_CONDITIONAL(HAVE_TEXI2DVI, test -n "$TEXI2DVI")
 
 AX_CC_MAXOPT


### PR DESCRIPTION
The `AC_CHECK_PROG` macro is misused. 
The third argument specifies the default value to assign if the program provided as the second argument is not found. However, the line `AM_CONDITIONAL(HAVE_TEXI2DVI, test -n "$TEXI2DVI")` incorrectly checks whether the variable `$TEXI2DVI` is empty, which never occurs. 
As a result, documentation is always attempted to be built, even if `texi2dvi` is not installed, causing compilation errors. 

This issue is resolved by assigning an empty string as the third argument.